### PR TITLE
Fix lighting section invocation

### DIFF
--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptScreen.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptScreen.kt
@@ -15,7 +15,7 @@ fun PromptScreen(
     when (uiState.currentStep) {
         PromptStep.Canvas -> CanvasSec(viewModel=viewModel, uiState = uiState)
         PromptStep.Camera -> CameraSec(viewModel=viewModel, uiState = uiState)
-        PromptStep.Lighting -> LightSec(viewModel=viewModel, uiState = uiState)
+        PromptStep.Lighting -> LightingSec(viewModel = viewModel, uiState = uiState)
         PromptStep.Person -> PersonSec(viewModel=viewModel, uiState = uiState)
         PromptStep.Others -> TextSec(viewModel=viewModel, uiState = uiState)
         PromptStep.Review -> Step6()


### PR DESCRIPTION
## Summary
- switch to `LightingSec` in PromptScreen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f6892fe088333a660e48a0d081f20