### PR TITLE
Add PromptViewModel unit tests

### DIFF
--- a/app/src/test/java/com/rururi/easyprompt/PromptViewModelTest.kt
+++ b/app/src/test/java/com/rururi/easyprompt/PromptViewModelTest.kt
@@ -1,0 +1,60 @@
+package com.rururi.easyprompt
+
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptStep
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PromptViewModelTest {
+    @Test
+    fun nextStep_movesThroughSteps() {
+        val viewModel = PromptViewModel()
+        // initial step is Canvas
+        assertEquals(PromptStep.Canvas, viewModel.uiState.value.currentStep)
+
+        viewModel.nextStep()
+        assertEquals(PromptStep.Camera, viewModel.uiState.value.currentStep)
+
+        viewModel.nextStep()
+        assertEquals(PromptStep.Lighting, viewModel.uiState.value.currentStep)
+
+        viewModel.nextStep()
+        assertEquals(PromptStep.Person, viewModel.uiState.value.currentStep)
+
+        viewModel.nextStep()
+        assertEquals(PromptStep.Others, viewModel.uiState.value.currentStep)
+
+        viewModel.nextStep()
+        assertEquals(PromptStep.Review, viewModel.uiState.value.currentStep)
+
+        // further nextStep should stay on Review
+        viewModel.nextStep()
+        assertEquals(PromptStep.Review, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun prevStep_movesBackThroughSteps() {
+        val viewModel = PromptViewModel()
+        repeat(5) { viewModel.nextStep() } // move to Review
+        assertEquals(PromptStep.Review, viewModel.uiState.value.currentStep)
+
+        viewModel.prevStep()
+        assertEquals(PromptStep.Others, viewModel.uiState.value.currentStep)
+
+        viewModel.prevStep()
+        assertEquals(PromptStep.Person, viewModel.uiState.value.currentStep)
+
+        viewModel.prevStep()
+        assertEquals(PromptStep.Lighting, viewModel.uiState.value.currentStep)
+
+        viewModel.prevStep()
+        assertEquals(PromptStep.Camera, viewModel.uiState.value.currentStep)
+
+        viewModel.prevStep()
+        assertEquals(PromptStep.Canvas, viewModel.uiState.value.currentStep)
+
+        // further prevStep should stay on Canvas
+        viewModel.prevStep()
+        assertEquals(PromptStep.Canvas, viewModel.uiState.value.currentStep)
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `PromptViewModel` next/prev step navigation

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f699b6ee88333a8b219a9bede8b88