### PR TITLE
Fix color selection issues

### DIFF
--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/Widget.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/Widget.kt
@@ -137,7 +137,7 @@ fun SetColor(
 
     if (showColorDialog) {
         ColorSelectDialog(
-            initialColor = Color.White,
+            initialColor = selectedColor,
             onColorSelected = {
                 onColorSelected(it)
                 showColorDialog = false

--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/05_Lighting.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/05_Lighting.kt
@@ -17,7 +17,7 @@ import com.rururi.easyprompt.ui.screen.RadioSelector
 import com.rururi.easyprompt.ui.screen.SetColor
 import com.rururi.easyprompt.ui.screen.SetRadio
 import com.rururi.easyprompt.ui.theme.EasyPromptTheme
-import androidx.core.graphics.toColorInt
+import com.rururi.easyprompt.ext.toColorOrDefault
 import com.rururi.easyprompt.ext.toRgbaString
 
 @Composable
@@ -60,7 +60,7 @@ fun LightingSec(
         SetColor(
             title = "光の色",
             onColorSelected = { viewModel.updateUiState({ copy(lightState = lightState.copy(color = it.toRgbaString())) }) },
-            selectedColor = Color(uiState.lightState.color.toColorInt()),
+            selectedColor = uiState.lightState.color.toColorOrDefault(),
         )
 
         Text(text = "■光の強度",style = MaterialTheme.typography.titleLarge)


### PR DESCRIPTION
## Summary
- fix SetColor to open dialog with current selection
- handle saved color values for lighting section

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f5dff09888333b2b67beada2a518a