### PR TITLE
Add more PromptViewModel tests

### DIFF
--- a/app/src/test/java/com/rururi/easyprompt/PromptViewModelTest.kt
+++ b/app/src/test/java/com/rururi/easyprompt/PromptViewModelTest.kt
@@ -2,6 +2,7 @@ package com.rururi.easyprompt
 
 import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
 import com.rururi.easyprompt.ui.screen.prompt.PromptStep
+import com.rururi.easyprompt.ui.screen.prompt.PromptType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -16,13 +17,13 @@ class PromptViewModelTest {
         assertEquals(PromptStep.Camera, viewModel.uiState.value.currentStep)
 
         viewModel.nextStep()
+        assertEquals(PromptStep.Theme, viewModel.uiState.value.currentStep)
+
+        viewModel.nextStep()
         assertEquals(PromptStep.Lighting, viewModel.uiState.value.currentStep)
 
         viewModel.nextStep()
         assertEquals(PromptStep.Person, viewModel.uiState.value.currentStep)
-
-        viewModel.nextStep()
-        assertEquals(PromptStep.Others, viewModel.uiState.value.currentStep)
 
         viewModel.nextStep()
         assertEquals(PromptStep.Review, viewModel.uiState.value.currentStep)
@@ -39,13 +40,13 @@ class PromptViewModelTest {
         assertEquals(PromptStep.Review, viewModel.uiState.value.currentStep)
 
         viewModel.prevStep()
-        assertEquals(PromptStep.Others, viewModel.uiState.value.currentStep)
-
-        viewModel.prevStep()
         assertEquals(PromptStep.Person, viewModel.uiState.value.currentStep)
 
         viewModel.prevStep()
         assertEquals(PromptStep.Lighting, viewModel.uiState.value.currentStep)
+
+        viewModel.prevStep()
+        assertEquals(PromptStep.Theme, viewModel.uiState.value.currentStep)
 
         viewModel.prevStep()
         assertEquals(PromptStep.Camera, viewModel.uiState.value.currentStep)
@@ -56,5 +57,100 @@ class PromptViewModelTest {
         // further prevStep should stay on Canvas
         viewModel.prevStep()
         assertEquals(PromptStep.Canvas, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun stepList_returnsCorrectStepsForEachPromptType() {
+        val viewModel = PromptViewModel()
+
+        viewModel.updateUiState { copy(promptType = PromptType.PERSON) }
+        assertEquals(
+            listOf(
+                PromptStep.Canvas,
+                PromptStep.Camera,
+                PromptStep.Theme,
+                PromptStep.Lighting,
+                PromptStep.Person,
+                PromptStep.Review
+            ),
+            viewModel.stepList()
+        )
+
+        viewModel.updateUiState { copy(promptType = PromptType.TEXT) }
+        assertEquals(
+            listOf(
+                PromptStep.Canvas,
+                PromptStep.Camera,
+                PromptStep.Theme,
+                PromptStep.Title,
+                PromptStep.Body,
+                PromptStep.Review
+            ),
+            viewModel.stepList()
+        )
+
+        viewModel.updateUiState { copy(promptType = PromptType.BACKGROUND) }
+        assertEquals(
+            listOf(
+                PromptStep.Canvas,
+                PromptStep.Camera,
+                PromptStep.Theme,
+                PromptStep.Lighting,
+                PromptStep.Review
+            ),
+            viewModel.stepList()
+        )
+    }
+
+    @Test
+    fun reset_setsDefaultPromptTypeAndStep() {
+        val viewModel = PromptViewModel()
+        viewModel.updateUiState {
+            copy(promptType = PromptType.TEXT, currentStep = PromptStep.Body)
+        }
+
+        viewModel.reset()
+
+        assertEquals(PromptType.PERSON, viewModel.uiState.value.promptType)
+        assertEquals(PromptStep.Canvas, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun buildYaml_generatesExpectedString() {
+        val viewModel = PromptViewModel()
+
+        viewModel.updateUiState {
+            copy(
+                canvasState = canvasState.copy(size = "1920x1080", type = "solid"),
+                cameraState = cameraState.copy(angle = "wide"),
+                themeSetState = themeSetState.copy(tone = "dark"),
+                personState = personState.copy(appearance = "tall"),
+                lightState = lightState.copy(style = "soft"),
+                titleState = titleState.copy(text = "Hello"),
+                bodyState = bodyState.copy(text = "World")
+            )
+        }
+
+        val expected = """
+            |prompt:
+            |  canvas:
+            |    size: \"1920x1080\"
+            |    background:
+            |      type: \"solid\"
+            |  camera:
+            |    angle: \"wide\"
+            |  theme:
+            |    tone: \"dark\"
+            |  person:
+            |    appearance: \"tall\"
+            |  light:
+            |    style: \"soft\"
+            |  title:
+            |    text: \"Hello\"
+            |  body:
+            |    text: \"World\"
+            |""".trimMargin() + "\n"
+
+        assertEquals(expected, viewModel.buildYaml())
     }
 }


### PR DESCRIPTION
## Summary
- update PromptViewModelTest for new step order
- add tests for stepList(), reset() and buildYaml()

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844e4ded7008333b014f0524ab58fc9