### PR TITLE
Add NavGraph tests

### DIFF
--- a/app/src/androidTest/java/com/rururi/easyprompt/NavGraphTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/NavGraphTest.kt
@@ -1,0 +1,55 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.navigation.NavGraph
+import com.rururi.easyprompt.ui.navigation.Screen
+import com.rururi.easyprompt.ui.screen.prompt.PromptType
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import org.junit.Assert.assertEquals
+
+class NavGraphTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var navController: TestNavHostController
+
+    @Before
+    fun setupNavGraph() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(composeTestRule.activity)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavGraph(
+                promptViewModel = PromptViewModel(),
+                navController = navController
+            )
+        }
+    }
+
+    @Test
+    fun startDestination_isHome() {
+        composeTestRule.runOnIdle {
+            assertEquals(Screen.Home.route, navController.currentDestination?.route)
+        }
+    }
+
+    @Test
+    fun navigateToPromptScreen_changesDestination() {
+        composeTestRule.runOnIdle {
+            navController.navigate("prompt/${PromptType.TEXT}")
+        }
+        composeTestRule.runOnIdle {
+            assertEquals(Screen.PromptWizard.route, navController.currentDestination?.route)
+            assertEquals(
+                PromptType.TEXT.name,
+                navController.currentBackStackEntry?.arguments?.getString("type")
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add instrumentation tests for NavGraph

## Testing
- `./gradlew test` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb256b408333ae41d1e4cca0b808