### PR TITLE
Add Compose UI tests for screens

### DIFF
--- a/app/src/androidTest/java/com/rururi/easyprompt/EasyPromptAppTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/EasyPromptAppTest.kt
@@ -1,0 +1,56 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.EasyPromptApp
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+
+class EasyPromptAppTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var navController: TestNavHostController
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(composeTestRule.activity)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            EasyPromptApp(promptViewModel = PromptViewModel())
+        }
+    }
+
+    @Test
+    fun navigateToPromptScreen_showsBars() {
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_prompt)
+        ).performClick()
+        composeTestRule.onNodeWithText("★ Canvas").assertExists()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_next)
+        ).assertExists()
+    }
+
+    @Test
+    fun homeButton_returnsToHome() {
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_prompt)
+        ).performClick()
+        composeTestRule.onNodeWithContentDescription(
+            composeTestRule.activity.getString(R.string.sc_home)
+        ).performClick()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_prompt)
+        ).assertExists()
+    }
+}
+

--- a/app/src/androidTest/java/com/rururi/easyprompt/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/HomeScreenTest.kt
@@ -1,0 +1,60 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.HomeScreen
+
+class HomeScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var personClicked = false
+    private var textClicked = false
+    private var backgroundClicked = false
+    private var resetCalled = false
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            HomeScreen(
+                onNavigateToPerson = { personClicked = true },
+                onNavigateToText = { textClicked = true },
+                onNavigateToBackground = { backgroundClicked = true },
+                onResetAll = { resetCalled = true }
+            )
+        }
+    }
+
+    @Test
+    fun buttons_triggerCallbacks() {
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_prompt)
+        ).performClick()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_text)
+        ).performClick()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_background)
+        ).performClick()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_full_reset)
+        ).performClick()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.dialog_reset)
+        ).performClick()
+        composeTestRule.runOnIdle {
+            assertTrue(personClicked)
+            assertTrue(textClicked)
+            assertTrue(backgroundClicked)
+            assertTrue(resetCalled)
+        }
+    }
+}
+

--- a/app/src/androidTest/java/com/rururi/easyprompt/PromptBottomBarTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/PromptBottomBarTest.kt
@@ -1,0 +1,56 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.PromptBottomBar
+import com.rururi.easyprompt.ui.screen.prompt.PromptStep
+import com.rururi.easyprompt.ui.screen.prompt.PromptType
+
+class PromptBottomBarTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun firstStep_showsNextOnly() {
+        composeTestRule.setContent {
+            PromptBottomBar(
+                currentStep = PromptStep.Canvas,
+                promptType = PromptType.PERSON,
+                onBack = {},
+                onNext = {},
+                onCopy = {},
+                copied = false
+            )
+        }
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.btn_back))
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.btn_next))
+            .assertExists()
+    }
+
+    @Test
+    fun reviewStep_showsCopyButton() {
+        var copiedCalled = false
+        composeTestRule.setContent {
+            PromptBottomBar(
+                currentStep = PromptStep.Review,
+                promptType = PromptType.PERSON,
+                onBack = {},
+                onNext = {},
+                onCopy = { copiedCalled = true },
+                copied = false
+            )
+        }
+        composeTestRule.onNodeWithText(composeTestRule.activity.getString(R.string.btn_copy))
+            .assertExists()
+            .performClick()
+        composeTestRule.runOnIdle { assertTrue(copiedCalled) }
+    }
+}
+

--- a/app/src/androidTest/java/com/rururi/easyprompt/PromptScreenTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/PromptScreenTest.kt
@@ -1,0 +1,43 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.PromptScreen
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptStep
+import com.rururi.easyprompt.ui.screen.prompt.PromptType
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class PromptScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var navController: TestNavHostController
+
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(composeTestRule.activity)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            PromptScreen(
+                navController = navController,
+                promptType = PromptType.PERSON,
+                viewModel = PromptViewModel(),
+                uiState = PromptUiState(currentStep = PromptStep.Camera)
+            )
+        }
+    }
+
+    @Test
+    fun cameraStep_displaysCameraSection() {
+        composeTestRule.onNodeWithText("カメラの角度").assertExists()
+    }
+}
+

--- a/app/src/androidTest/java/com/rururi/easyprompt/PromptTopBarTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/PromptTopBarTest.kt
@@ -1,0 +1,48 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.PromptTopBar
+import com.rururi.easyprompt.ui.screen.prompt.PromptStep
+
+class PromptTopBarTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var homeClicked = false
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            PromptTopBar(
+                currentStep = PromptStep.Canvas,
+                onHome = { homeClicked = true }
+            )
+        }
+    }
+
+    @Test
+    fun titleIsDisplayed() {
+        composeTestRule.onNodeWithText("★ ${PromptStep.Canvas.displayName}")
+            .assertExists()
+    }
+
+    @Test
+    fun homeButtonCallsCallback() {
+        composeTestRule.onNodeWithContentDescription(
+            composeTestRule.activity.getString(R.string.sc_home)
+        ).performClick()
+        composeTestRule.runOnIdle {
+            assertTrue(homeClicked)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- write UI tests for key screens using Compose

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6845f0ff38b08333b549bc3449d6d66e