### PR TITLE
Add Compose UI tests for prompt sections

### DIFF
--- a/app/src/androidTest/java/com/rururi/easyprompt/BodySecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/BodySecTest.kt
@@ -1,0 +1,30 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.BodySec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class BodySecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            BodySec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysBodyOptions() {
+        composeTestRule.onNodeWithText("本文を入力してください。").assertExists()
+        composeTestRule.onNodeWithText("タイトルのフォント").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/CameraSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/CameraSecTest.kt
@@ -1,0 +1,30 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.CameraSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class CameraSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            CameraSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysCameraOptions() {
+        composeTestRule.onNodeWithText("カメラの角度").assertExists()
+        composeTestRule.onNodeWithText("カメラのフレーミング").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/CanvasSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/CanvasSecTest.kt
@@ -1,0 +1,30 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.CanvasSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class CanvasSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            CanvasSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysCanvasOptions() {
+        composeTestRule.onNodeWithText("キャンバスの大きさ").assertExists()
+        composeTestRule.onNodeWithText("背景の種類").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/LightingSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/LightingSecTest.kt
@@ -1,0 +1,33 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.LightingSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class LightingSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            LightingSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysLightingOptions() {
+        composeTestRule.onNodeWithText("ライティングスタイル").assertExists()
+        composeTestRule.onNodeWithText("光の方向").assertExists()
+        composeTestRule.onNodeWithText("光の色").assertExists()
+        composeTestRule.onNodeWithText("■光の強度").assertExists()
+        composeTestRule.onNodeWithText("■光のコントラスト").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/PersonSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/PersonSecTest.kt
@@ -1,0 +1,31 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.PersonSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class PersonSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            PersonSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysPersonFields() {
+        composeTestRule.onNodeWithText("外見").assertExists()
+        composeTestRule.onNodeWithText("表情").assertExists()
+        composeTestRule.onNodeWithText("ポーズ").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/ReviewSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/ReviewSecTest.kt
@@ -1,0 +1,38 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.ReviewSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class ReviewSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            ReviewSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysPreviewTitle_andToggleEdit() {
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.preview_title)
+        ).assertExists()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_edit)
+        ).performClick()
+        composeTestRule.onNodeWithText(
+            composeTestRule.activity.getString(R.string.btn_edited)
+        ).assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/ThemeSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/ThemeSecTest.kt
@@ -1,0 +1,30 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.ThemeSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class ThemeSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            ThemeSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysThemeOptions() {
+        composeTestRule.onNodeWithText("テーマのトーン・ムード").assertExists()
+        composeTestRule.onNodeWithText("キーワード(3,4個程度)").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/rururi/easyprompt/TitleSecTest.kt
+++ b/app/src/androidTest/java/com/rururi/easyprompt/TitleSecTest.kt
@@ -1,0 +1,30 @@
+package com.rururi.easyprompt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import com.rururi.easyprompt.ui.screen.prompt.TitleSec
+import com.rururi.easyprompt.ui.screen.prompt.PromptViewModel
+import com.rururi.easyprompt.ui.screen.prompt.PromptUiState
+
+class TitleSecTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            TitleSec(viewModel = PromptViewModel(), uiState = PromptUiState())
+        }
+    }
+
+    @Test
+    fun displaysTitleOptions() {
+        composeTestRule.onNodeWithText("タイトルを決めてください").assertExists()
+        composeTestRule.onNodeWithText("タイトルのフォント").assertExists()
+    }
+}


### PR DESCRIPTION
## Summary
- add android instrumentation tests for each prompt section composable

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to tunnel through proxy)*
- `./gradlew lintVitalRelease` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e80301e0c8333ba5f5760a6713c37