### PR TITLE
Improve prompt screen imports

### DIFF
--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/03_ThemeSet.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/03_ThemeSet.kt
@@ -1,6 +1,5 @@
 package com.rururi.easyprompt.ui.screen.prompt
 
-import android.R.style.Theme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptBottomBar.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptBottomBar.kt
@@ -1,7 +1,5 @@
 package com.rururi.easyprompt.ui.screen.prompt
 
-import android.R.attr.onClick
-import android.R.id.message
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,7 +19,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import com.rururi.easyprompt.R
 import com.rururi.easyprompt.ui.theme.EasyPromptTheme
 import com.rururi.easyprompt.utils.log
-import kotlinx.coroutines.NonCancellable.isActive
 
 @Composable
 fun PromptBottomBar(

--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptScreen.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptScreen.kt
@@ -1,14 +1,6 @@
 package com.rururi.easyprompt.ui.screen.prompt
 
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.res.stringResource
-import com.rururi.easyprompt.R
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.navigation.NavController
 
 @Composable
@@ -18,7 +10,7 @@ fun PromptScreen(
     viewModel: PromptViewModel,
     uiState: PromptUiState,
 ) {
-    var currentStep = uiState.currentStep
+    val currentStep = uiState.currentStep
 
     when (currentStep) {
         PromptStep.Canvas -> CanvasSec(viewModel=viewModel, uiState = uiState)

--- a/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptTopBar.kt
+++ b/app/src/main/java/com/rururi/easyprompt/ui/screen/prompt/PromptTopBar.kt
@@ -1,6 +1,5 @@
 package com.rururi.easyprompt.ui.screen.prompt
 
-import android.R.attr.navigationIcon
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons


### PR DESCRIPTION
## Summary
- clean up unused Android imports
- use `val` for currentStep in PromptScreen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6856383f18948333a2ead599a9ea30c5